### PR TITLE
feat: volume-backed builds, runtime module deps, enhanced doctor

### DIFF
--- a/west_commands/env.py
+++ b/west_commands/env.py
@@ -2,7 +2,6 @@
 
 import sys
 from pathlib import Path
-import inspect
 import argparse
 import subprocess
 import configparser
@@ -15,37 +14,33 @@ if str(REPO_ROOT) not in sys.path:
 from west.commands import WestCommand
 from west.util import west_topdir
 from west_env.config import load_config
-from west_env.container import run_container, check_container, CONTAINER_WORKDIR
+from west_env.container import (
+    run_container,
+    run_container_volume,
+    extract_artifacts,
+    check_container,
+    CONTAINER_WORKDIR,
+)
+from west_env.engine import get_engine
 from west_env.util import run_host, check_python, check_west
 
 
 def _read_west_manifest_location(topdir: Path) -> tuple[str, str]:
-    """
-    Return (manifest_path, manifest_file) from .west/config.
-
-    manifest_path is the directory which contains the manifest file,
-    relative to the west topdir (e.g. "workspace").
-    manifest_file is typically "west.yml".
-    """
     cfg_path = topdir / ".west" / "config"
     cp = configparser.ConfigParser()
     cp.read(cfg_path)
-
-    # West stores this in [manifest] path=..., file=...
     mpath = cp.get("manifest", "path", fallback=".")
     mfile = cp.get("manifest", "file", fallback="west.yml")
     return mpath, mfile
 
 
 def validate_workspace_layout():
-    # NOTE: west_topdir() is the directory containing .west/
     topdir = Path(west_topdir()).resolve()
     errors = []
 
     if not (topdir / ".west").is_dir():
         errors.append(".west directory not found")
 
-    # Validate the configured manifest file exists (supports manifest in subdir)
     try:
         mpath, mfile = _read_west_manifest_location(topdir)
         manifest = (topdir / mpath / mfile).resolve()
@@ -70,7 +65,7 @@ class EnvCommand(WestCommand):
         super().__init__(
             "env",
             "Manage reproducible build environments",
-            "init | build [west build args...] | shell | doctor",
+            "init | build | shell | doctor",
         )
 
     def do_add_parser(self, parser_adder):
@@ -105,30 +100,41 @@ class EnvCommand(WestCommand):
         cfg = load_config()
         use_container = args.container or cfg.env_type == "container"
         passthrough = [a for a in args.args if a != "--container"]
+        use_volume = use_container and cfg.sync_mode == "volume"
 
         if args.action == "init":
             print("Initializing environment...")
             if use_container:
                 validate_workspace_layout()
-                self._run_container(cfg, ["true"])
+                run_container(cfg, ["true"])
             else:
                 print("Native environment selected")
 
         elif args.action == "build":
+            build_dir = self._extract_build_dir(passthrough)
             passthrough = self._inject_build_dir(
                 cfg, passthrough, use_container
             )
             cmd = ["west", "build"] + passthrough
-            if use_container:
+            if use_volume:
                 validate_workspace_layout()
-                self._run_container(cfg, cmd)
+                run_container_volume(cfg, cmd, build_dir=build_dir)
+                if build_dir:
+                    extract_artifacts(cfg, build_dir)
+            elif use_container:
+                validate_workspace_layout()
+                run_container(cfg, cmd)
             else:
                 run_host(cmd)
 
         elif args.action == "shell":
-            if use_container:
+            if use_volume:
                 validate_workspace_layout()
-                self._run_container(cfg, ["/bin/bash"], interactive=True)
+                print("NOTE: volume mode -- host edits require re-sync (exit and re-enter).")
+                run_container_volume(cfg, ["/bin/bash"], interactive=True)
+            elif use_container:
+                validate_workspace_layout()
+                run_container(cfg, ["/bin/bash"], interactive=True)
             else:
                 run_host(["bash"])
 
@@ -136,11 +142,16 @@ class EnvCommand(WestCommand):
             self._doctor(cfg, use_container)
 
     @staticmethod
+    def _extract_build_dir(passthrough):
+        for i, arg in enumerate(passthrough):
+            if arg in ("--build-dir", "-d") and i + 1 < len(passthrough):
+                return passthrough[i + 1]
+        return None
+
+    @staticmethod
     def _inject_build_dir(cfg, passthrough, use_container):
-        """Inject --build-dir from west-env.yml if not already specified."""
         if not cfg.build_dir:
             return passthrough
-        # Don't override an explicit user --build-dir / -d
         for arg in passthrough:
             if arg in ("--build-dir", "-d"):
                 return passthrough
@@ -150,17 +161,9 @@ class EnvCommand(WestCommand):
             bd = str(Path(west_topdir()).resolve() / cfg.build_dir)
         return ["--build-dir", bd] + passthrough
 
-    @staticmethod
-    def _run_container(cfg, cmd, interactive=False):
-        try:
-            sig = inspect.signature(run_container)
-            kwargs = {}
-            if "interactive" in sig.parameters:
-                kwargs["interactive"] = interactive
-            return run_container(cfg, cmd, **kwargs)
-        except TypeError:
-            return run_container(cfg, cmd, interactive=interactive)
-
+    # ---------------------------------------------------------------
+    # doctor
+    # ---------------------------------------------------------------
     def _doctor(self, cfg, use_container):
         print("west-env doctor\n")
 
@@ -169,34 +172,62 @@ class EnvCommand(WestCommand):
         ok &= check_west()
 
         if use_container:
-            ok &= check_container(cfg)
-            ok &= self._doctor_container_workspace(cfg)
+            engine_ok = check_container(cfg)
+            ok &= engine_ok
+
+            if engine_ok:
+                ok &= self._doctor_container_workspace(cfg)
+
+                if cfg.sync_mode == "volume":
+                    ok &= self._doctor_volume(cfg)
+
         else:
             print("[INFO] container execution disabled")
 
         print()
         if ok:
-            print("Environment looks good ✔")
+            print("Environment looks good \u2714")
         else:
-            print("One or more checks failed ✖")
+            print("One or more checks failed \u2716")
+
+    @staticmethod
+    def _doctor_volume(cfg):
+        try:
+            engine, _ = get_engine(cfg.engine)
+            subprocess.check_output(
+                [engine.name, "volume", "ls"],
+                stderr=subprocess.DEVNULL,
+            )
+            print("[PASS] volume management")
+            return True
+        except Exception:
+            print("[WARN] container engine cannot list volumes")
+            print("       ensure the Docker/Podman daemon is running")
+            return True  # non-fatal
 
     @staticmethod
     def _doctor_container_workspace(cfg):
-        """
-        Verify the container can see:
-          - .west/ at /work (west topdir)
-          - the configured manifest file (often workspace/west.yml)
-        """
         topdir = Path(west_topdir()).resolve()
-
-        # Compute manifest location from host .west/config, then check in-container
         mpath, mfile = _read_west_manifest_location(topdir)
         manifest_rel = f"{mpath.rstrip('/')}/{mfile}".lstrip("./")
+
+        engine, _ = get_engine(cfg.engine)
+
+        # Skip when image not yet pulled
+        try:
+            subprocess.check_output(
+                [engine.name, "image", "inspect", cfg.image],
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            print("[SKIP] container workspace visibility")
+            print("       image not present locally; will be checked on first use")
+            return True
 
         try:
             subprocess.check_output(
                 [
-                    "docker",
+                    engine.name,
                     "run",
                     "--rm",
                     "-v",
@@ -212,7 +243,7 @@ class EnvCommand(WestCommand):
             )
             print("[PASS] container workspace visibility")
             return True
-        except Exception:  # noqa
+        except Exception:
             print("[FAIL] container cannot see a valid workspace at /work")
             print("       expected .west/ and configured manifest file")
             print(f"       manifest: {manifest_rel}")

--- a/west_env/config.py
+++ b/west_env/config.py
@@ -12,6 +12,9 @@ class EnvConfig:
         self.image = self.container.get("image")
         self.engine = self.container.get("engine", "docker")
 
+        # "bind" (default) or "volume" (sync-build-extract for Windows perf)
+        self.sync_mode = self.container.get("sync_mode", "bind")
+
         # Optional build directory (relative to west topdir)
         build = data.get("env", {}).get("build", {})
         self.build_dir = build.get("dir")  # e.g. "build"

--- a/west_env/container.py
+++ b/west_env/container.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 from pathlib import Path
 import subprocess
 from west.util import west_topdir
@@ -8,33 +9,71 @@ from west_env.engine import get_engine
 CONTAINER_WORKDIR = "/work"
 
 
+def _volume_name(workspace: Path) -> str:
+    """Deterministic volume name for the build cache."""
+    digest = hashlib.sha256(str(workspace).encode()).hexdigest()[:12]
+    return f"west-env-build-{digest}"
+
+
+def _ensure_volume(engine, name: str):
+    """Create a named volume if it does not already exist."""
+    result = subprocess.run(
+        [engine.name, "volume", "inspect", name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        subprocess.check_call(
+            [engine.name, "volume", "create", name],
+            stdout=subprocess.DEVNULL,
+        )
+
+
+def _container_workdir(workspace: Path) -> str:
+    """Compute the container working directory from host cwd."""
+    host_cwd = Path.cwd().resolve()
+    try:
+        rel = host_cwd.relative_to(workspace)
+        rel_posix = rel.as_posix()
+        return (
+            CONTAINER_WORKDIR
+            if rel_posix == "."
+            else f"{CONTAINER_WORKDIR}/{rel_posix}"
+        )
+    except ValueError:
+        return CONTAINER_WORKDIR
+
+
+def _git_safe_dir_cmd():
+    return "git config --global safe.directory '*'"
+
+
+def _container_prep_cmd():
+    """Commands to run before the main command inside the container.
+
+    Installs project-specific Python deps that may not be in the base image.
+    Uses --quiet and allows failure on individual packages so the build
+    isn't blocked by optional deps.
+    """
+    return (
+        "pip install --quiet --disable-pip-version-check "
+        "-r /work/external/zephyr/modules/canopennode/zephyr/requirements.txt "
+        "2>/dev/null || true"
+    )
+
+
+# -----------------------------------------------------------------
+# Bind-mount mode (original behavior)
+# -----------------------------------------------------------------
 def run_container(cfg, command, interactive=False):
     engine, warned = get_engine(cfg.engine)
 
     if warned:
         print("[WARN] Both Docker and Podman detected; using Docker")
 
-    # Canonical west topdir (directory containing .west/)
     workspace = Path(west_topdir()).resolve()
+    container_wd = _container_workdir(workspace)
 
-    # Host cwd (perhaps inside the workspace)
-    host_cwd = Path.cwd().resolve()
-
-    try:
-        rel = host_cwd.relative_to(workspace)
-        rel_posix = rel.as_posix()
-        # rel_posix is '.' when cwd equals the workspace root; avoid '/work/.'
-        container_wd = (
-            CONTAINER_WORKDIR
-            if rel_posix == "."
-            else f"{CONTAINER_WORKDIR}/{rel_posix}"
-        )
-    except ValueError:
-        container_wd = CONTAINER_WORKDIR
-
-    # -------------------------------------------------
-    # Prepare container invocation
-    # -------------------------------------------------
     args = [
         "run",
         "--rm",
@@ -49,36 +88,106 @@ def run_container(cfg, command, interactive=False):
     if interactive:
         args.append("-it")
 
-    # -------------------------------------------------
-    # Git safety + command execution
-    #
-    # Git >= 2.35 refuses to operate on bind-mounted repos
-    # owned by a different uid (common in Docker) unless
-    # the directory is explicitly marked safe.
-    #
-    # We use the '*' wildcard to cover the entire workspace
-    # tree regardless of how the user has named and placed
-    # their Zephyr project path in west.yml.  A hardcoded
-    # path such as '/work/zephyr' breaks any project whose
-    # zephyr/ directory is already taken by a Zephyr module
-    # integration directory (zephyr/module.yml), forcing
-    # them to use an alternate path (e.g. deps/zephyr).
-    #
-    # Using '*' is intentional and safe: the container is
-    # already a trust boundary.
-    # -------------------------------------------------
-    git_prep = "git config --global safe.directory '*'"
-
     full_cmd = " ".join(command)
-
     args.append(cfg.image)
     args.extend([
         "sh",
         "-c",
-        f"{git_prep} && exec {full_cmd}",
+        f"{_git_safe_dir_cmd()} && {_container_prep_cmd()} && exec {full_cmd}",
     ])
 
     engine.run(args)
+
+
+# -----------------------------------------------------------------
+# Volume mode:
+#
+# The workspace (source, .west/, external/) is bind-mounted from the
+# host so west can resolve the manifest and find all modules.  Only
+# the build output directory is placed on a named Docker volume for
+# fast I/O.  This avoids the expensive NTFS-to-ext4 translation for
+# the thousands of intermediate files cmake/ninja produce.
+#
+# After the build, final artifacts (ELF, HEX, MAP) are extracted
+# back to the host so flash and debug tools can access them.
+# -----------------------------------------------------------------
+def run_container_volume(cfg, command, interactive=False, build_dir=None):
+    """Run a command with bind-mounted workspace + build-dir on a volume."""
+    engine, warned = get_engine(cfg.engine)
+
+    if warned:
+        print("[WARN] Both Docker and Podman detected; using Docker")
+
+    workspace = Path(west_topdir()).resolve()
+    container_wd = _container_workdir(workspace)
+    vol = _volume_name(workspace)
+    _ensure_volume(engine, vol)
+
+    # Container build path (posix)
+    if build_dir:
+        container_build = f"{CONTAINER_WORKDIR}/{build_dir.replace(chr(92), '/')}"
+    else:
+        container_build = f"{CONTAINER_WORKDIR}/build"
+
+    args = [
+        "run",
+        "--rm",
+        "-v", f"{workspace}:{CONTAINER_WORKDIR}",
+        "-v", f"{vol}:{container_build}",
+        "-w", container_wd,
+        "-e", "PYTHONPATH=/work/modules/west-env",
+    ]
+
+    if interactive:
+        args.append("-it")
+
+    full_cmd = " ".join(command)
+    args.append(cfg.image)
+    args.extend([
+        "sh",
+        "-c",
+        f"{_git_safe_dir_cmd()} && {_container_prep_cmd()} && exec {full_cmd}",
+    ])
+
+    engine.run(args)
+
+
+def extract_artifacts(cfg, build_dir):
+    """Copy final build artifacts from the volume back to the host."""
+    engine, _ = get_engine(cfg.engine)
+    workspace = Path(west_topdir()).resolve()
+    vol = _volume_name(workspace)
+    container_build = f"{CONTAINER_WORKDIR}/{build_dir.replace(chr(92), '/')}"
+
+    # Ensure host build directory exists
+    host_build = workspace / build_dir.replace("\\", "/")
+    host_build.mkdir(parents=True, exist_ok=True)
+
+    # Extract only the final artifacts (small, fast)
+    artifact_globs = "zephyr/zephyr.elf zephyr/zephyr.hex zephyr/zephyr.bin zephyr/zephyr.map zephyr/.config"
+
+    print(f"Extracting build artifacts ...")
+
+    dump_cmd = [
+        engine.name, "run", "--rm",
+        "-v", f"{vol}:{container_build}",
+        "-w", container_build,
+        cfg.image,
+        "sh", "-c",
+        f"tar cf - {artifact_globs} 2>/dev/null",
+    ]
+
+    extract_cmd = ["tar", "xf", "-", "-C", str(host_build)]
+
+    dump_proc = subprocess.Popen(dump_cmd, stdout=subprocess.PIPE)
+    ext_proc = subprocess.Popen(extract_cmd, stdin=dump_proc.stdout)
+    dump_proc.stdout.close()
+    ext_proc.communicate()
+
+    if ext_proc.returncode != 0:
+        print("WARNING: artifact extraction may have been incomplete")
+    else:
+        print("Artifacts extracted.")
 
 
 def check_container(cfg):


### PR DESCRIPTION
- config: add sync_mode (bind/volume) for build output volume support
- container: add run_container_volume() with bind-mount workspace + named volume for build output directory (fast I/O on Windows/WSL2)
- container: add extract_artifacts() to copy ELF/HEX/MAP back to host
- container: add _container_prep_cmd() for runtime pip install of project-specific Python deps (e.g. eds-utils for CANopenNode)
- env: route build/shell through volume path when sync_mode=volume
- doctor: use detected engine (not hardcoded docker) in workspace check
- doctor: skip workspace visibility check when image not yet pulled
- doctor: add volume management check
- doctor: short-circuit dependent checks when engine check fails